### PR TITLE
Fixed bugs

### DIFF
--- a/forums/post.php
+++ b/forums/post.php
@@ -184,7 +184,7 @@
 <?php	if ($_GET['preview'] && strlen($fillVars['message']) > 0) { ?>
 		<h2>Preview:</h2>
 		<div id="preview">
-			<?=BBCode2Html(printReady($fillVars['message']))."\n"?>
+			<?=printReady(BBCode2Html($fillVars['message']))."\n"?>
 		</div>
 		<hr>
 


### PR DESCRIPTION
Post preview uses BBCode2Html and printReady in a different order to the thread display (forums/thread.php:212).  It usually doesn't make a difference, but there are edge cases where the preview is not a true representation of the final post.