### PR TITLE
Features/private sections

### DIFF
--- a/fixedGameMenu.php
+++ b/fixedGameMenu.php
@@ -134,7 +134,7 @@
 						}
 					}
 ?>
-					<p class="charName"><a href="/characters/<?=$charInfo['system']?>/<?=$charInfo['characterID']?>/"><?=$charInfo['label']?></a></p>
+					<p class="charName"><a href="/characters/<?=$charInfo['system']?>/<?=$charInfo['characterID']?>/" class="charid-<?=$charInfo['characterID']?>"><?=$charInfo['label']?></a></p>
 <?php				} ?>
 				</li>
 			</ul>

--- a/forums/post.php
+++ b/forums/post.php
@@ -251,7 +251,7 @@
 				foreach ($pcCharacters as $characterID => $name) { ?>
 							<option value="<?=$characterID?>"<?=$currentChar == $characterID ? ' selected="selected"' : ''?>><?=$name?></option>
 <?php			}} ?>
-						</select></div>
+						</select> <span id="charSheetLink"></span></div>
 					</div>
 <?php	}?>
 				</div>

--- a/forums/post.php
+++ b/forums/post.php
@@ -72,6 +72,10 @@
 								$quoteInfo['message'] = Post::cleanNotes($quoteInfo['message']);
 							}
 						}
+						else{
+							$quoteInfo['message'] = Post::cleanNotes($quoteInfo['message']);
+						}
+						
 						$post->message = '[quote="' . $quoteInfo['username'] . '"]' . $quoteInfo['message'] . '[/quote]';
 					}
 				}

--- a/forums/process/post.php
+++ b/forums/process/post.php
@@ -33,10 +33,10 @@
 			$gameID = (int) $mysql->query("SELECT gameID FROM forums f WHERE forumID = ".intval($_POST['new'])." LIMIT 1")->fetchColumn();
 		}
 
-		if (preg_match_all('/\[note="?(\w[\w +;,]+?)"?](.*?)\[\/note\]/ms', $message, $matches, PREG_SET_ORDER)) {
+		if (preg_match_all('/\[(note|private)="?(\w[\w +;,]+?)"?](.*?)\[\/(note|private)\]/ms', $message, $matches, PREG_SET_ORDER)) {
 			$allUsers = [];
 			foreach ($matches as $match) {
-				foreach (preg_split('/[^\w]+/', $match[1]) as $eachUser) {
+				foreach (preg_split('/[^\w]+/', $match[2]) as $eachUser) {
 					$allUsers[] = $eachUser;
 				}
 			}
@@ -52,7 +52,7 @@
 				}
 			}
 			foreach ($matches as $match) {
-				$matchUsers = preg_split('/[^\w]+/', $match[1]);
+				$matchUsers = preg_split('/[^\w]+/', $match[2]);
 				$validUsers = [];
 				foreach ($matchUsers as $user) {
 					foreach ($allUsers as $realUser) {
@@ -61,7 +61,7 @@
 						}
 					}
 				}
-				$validNote = preg_replace('/\[note.*?\]/', '[note="'.implode(',', $validUsers).'"]', $match[0]);
+				$validNote = preg_replace('/\['.$match[1].'.*?\]/', '['.$match[1].'="'.implode(',', $validUsers).'"]', $match[0]);
 				$message = str_replace($match[0], $validNote, $message);
 			}
 		}

--- a/forums/thread.php
+++ b/forums/thread.php
@@ -349,7 +349,7 @@
 <?php			foreach ($characters as $characterID => $name) { ?>
 						<option value="<?=$characterID?>"<?=$currentChar == $characterID ? ' selected="selected"' : ''?>><?=$name?></option>
 <?php			} ?>
-					</select></div>
+					</select> <span id="charSheetLink"></span></div>
 				</div>
 <?php		} ?>
 				<textarea id="messageTextArea" name="message"></textarea>

--- a/includes/forums/Post.class.php
+++ b/includes/forums/Post.class.php
@@ -125,6 +125,19 @@
 				}
 			}
 
+			preg_match_all('/\[private="?(\w[\w\. +;,]+?)"?](.*?)\[\/private\][\n\r]*/ms', $message, $matches, PREG_SET_ORDER);
+			if (sizeof($matches)) {
+				foreach ($matches as $match) {
+					$noteTo = preg_split('/[^\w\.]+/', $match[1]);
+					if (!in_array($currentUser->username, $noteTo)) {
+						$message = str_replace($match[0], '', $message);
+					} else {
+						$message = str_replace($match[0], $match[2].chr(13), $message);
+					}
+					
+				}
+			}			
+
 			return trim($message);
 		}
 

--- a/javascript/forums/unsaved-work.js
+++ b/javascript/forums/unsaved-work.js
@@ -11,3 +11,21 @@ window.onbeforeunload = function ()
         return "You haven't submitted your post. Click OK to continue without saving or Cancel to go back and save your post.";
     }
 };
+
+$(function() {
+
+    var updateCharLink=function(postAs){
+        var charPost=$('#fm_characters .charid-'+postAs.val());
+        var charSheetLink=$('#charSheetLink').html('');
+        if(charPost.length>0){
+            charPost=charPost.eq(0);
+            $('<a target="_blank"></a>').text(charPost.text()).attr('href',charPost.attr('href')).appendTo(charSheetLink);
+        }
+    };
+
+    $('select[name="postAs"]').on('change',function(){
+        updateCharLink($(this));
+    });
+    
+    updateCharLink($('select[name="postAs"]'));
+});

--- a/javascript/markItUp/markitup.bbcode-parser.php
+++ b/javascript/markItUp/markitup.bbcode-parser.php
@@ -34,6 +34,10 @@
 function BBCode2Html($text) {
 	$text = trim($text);
 
+	//iOS uses smart quotes.  Replace those as they might be tag attributes.
+	$text = str_replace('“', '"', $text);
+	$text = str_replace('”', '"', $text);
+
 	// BBCode [code]
 	if (!function_exists('escape')) {
 		function escape($s) {
@@ -210,6 +214,19 @@ function BBCode2Html($text) {
 				}
 			}
 		}
+
+		$text = preg_replace('/\[private="?(\w[\w\. +;,]+?)"?](.*?)\[\/private\]\s*/s', '<aside class="private"><div>Privately: \1</div>\2</aside>', $text);
+		if (strpos($text, 'aside class="private"') !== false && !$isGM && $post->getAuthor('userID') != $currentUser->userID && preg_match_all('/\<aside class="private"\>\<div\>Privately: (.*?)\<\/div\>(.*?)\<\/aside\>/ms', $text, $matches, PREG_SET_ORDER)) {
+			foreach ($matches as $match) {
+				$noteTo = array_map('strtolower', preg_split('/[^\w\.]+/', $match[1]));
+				if (!in_array(strtolower($currentUser->username), $noteTo)) {
+					$text = str_replace($match[0], '', $text);
+				}
+				else{
+					$text = str_replace($match[0], $match[2].'<br/>', $text);
+				}
+			}
+		}		
 	}
 
 // paragraphs

--- a/javascript/versions.json
+++ b/javascript/versions.json
@@ -73,7 +73,7 @@
 	"/javascript/ucp/user.js": "1.0.5",
 	"/node_modules/rx/dist/rx.all.min.js": "4.1.0",
 	"/node_modules/rx-angular/dist/rx.angular.min.js": "1.1.3",
-	"/javascript/forums/unsaved-work.js": "1.0.0",
+	"/javascript/forums/unsaved-work.js": "1.0.1",
 	"/javascript/markItUp/sets/bbcode/game-forum-set.js": "1.0.3",
 	"/javascript/gameOptions.js": "1.0.1"
 }

--- a/styles/gamersPlane.less
+++ b/styles/gamersPlane.less
@@ -1500,7 +1500,7 @@ input[type="text"], textarea {
 /* ----------------------------------------------------------------------------------------------*/
 /* Spoilers and quotes can also appear on char sheet notes */
 
-.quote, .note, .spoiler {
+.quote, .note, .spoiler, .private {
 	margin: 10px;
 	padding: 8px;
 	border: 1px solid #666;
@@ -1514,7 +1514,7 @@ input[type="text"], textarea {
 	color: #44B;
 }
 
-.quote, .note, .oocText, .spoiler {
+.quote, .note, .oocText, .spoiler, .private {
 	div:first-child {
 		font-size: .85em;
 		line-height: 1em;

--- a/styles/versions.json
+++ b/styles/versions.json
@@ -12,7 +12,7 @@
 	"/styles/forums.css": "1.6.3",
 	"/styles/games.css": "1.3.0",
 	"/styles/gamersList.css": "1.1.2",
-	"/styles/gamersPlane.css": "1.11.7",
+	"/styles/gamersPlane.css": "1.11.8",
 	"/styles/pms.css": "1.1.0",
 	"/styles/tools.css": "1.2.0",
 	"/styles/ucp.css": "1.0.2",


### PR DESCRIPTION
Fixes privacy issue when quoting a post with a private note in a non-game forum.  The private note contents become visible to everyone. To repro: https://gamersplane.com/forums/post/16023/?quote=905070

iOS smart quotes are replaced with regular quotes as they cause problems when used in tag attributes.

New [private="user list"][/private] tag.  Works like note but other users don't see that a note has been sent (or that it's a note).  See https://discord.com/channels/383334180010065921/847468766149476394/869545906624692315 for use case and discussion.