### PR TITLE
Styling for dice on mobile.  d case insensitive.

### DIFF
--- a/javascript/gameOptions.js
+++ b/javascript/gameOptions.js
@@ -44,7 +44,7 @@ $(function () {
 
             for (var count = 0; count < gameOptions.diceRules.length; count++) {
                 var rule = gameOptions.diceRules[count];
-                if(rollstring &&  rollstring.indexOf(rule.rolled)!=-1){
+                if(rollstring && rule.rolled &&  rollstring.toLowerCase().indexOf(rule.rolled.toLowerCase())!=-1){
                     //rules highlighting
                     if(rule.highlight){
                         var highlightClass=rule.highlight.split(" ").map(function(item) {

--- a/javascript/versions.json
+++ b/javascript/versions.json
@@ -75,5 +75,5 @@
 	"/node_modules/rx-angular/dist/rx.angular.min.js": "1.1.3",
 	"/javascript/forums/unsaved-work.js": "1.0.1",
 	"/javascript/markItUp/sets/bbcode/game-forum-set.js": "1.0.3",
-	"/javascript/gameOptions.js": "1.0.1"
+	"/javascript/gameOptions.js": "1.0.2"
 }

--- a/styles/forums.less
+++ b/styles/forums.less
@@ -512,7 +512,7 @@
 	cursor: pointer;
 	
 	i{
-		display: inline-block;
+		display: inline;
 		padding: 0 .2em;
 		&:after{
 			content:',';

--- a/styles/versions.json
+++ b/styles/versions.json
@@ -9,7 +9,7 @@
 	"/styles/characters/shadowrun5.css": "1.0.3",
 	"/styles/characters/tor.css": "1.0.1",
 	"/styles/characters/wod.css": "1.0.1",
-	"/styles/forums.css": "1.6.3",
+	"/styles/forums.css": "1.6.4",
 	"/styles/games.css": "1.3.0",
 	"/styles/gamersList.css": "1.1.2",
 	"/styles/gamersPlane.css": "1.11.8",


### PR DESCRIPTION
Dice rolls appear too small on mobile devices.
d notation rules now case insensitive (e.g. d6 vs D6)