### PR TITLE
Remove forced white background on avatar images

### DIFF
--- a/styles/forums.less
+++ b/styles/forums.less
@@ -366,7 +366,6 @@
 			-webkit-border-radius: 6px;
 			-moz-border-radius: 6px;
 			border-radius: 6px;
-			background-color: #FFF;
 		}
 	}
 


### PR DESCRIPTION
Using the dark theme, avatar images with transparency end up with a
white background.

Removing the CSS background-color element results in them taking on the
background color from the theme.