### PR TITLE
Remove border around avatar images

### DIFF
--- a/styles/forums.less
+++ b/styles/forums.less
@@ -362,10 +362,6 @@
 		img {
 			max-width: 100px;
 			max-height: 100px;
-			border: 1px solid #888;
-			-webkit-border-radius: 6px;
-			-moz-border-radius: 6px;
-			border-radius: 6px;
 		}
 	}
 

--- a/styles/user.less
+++ b/styles/user.less
@@ -12,10 +12,6 @@
 
 	.avatar {
 		padding: 5px;
-		border: 1px solid #777;
-		-webkit-border-radius: 5px;
-		-moz-border-radius: 5px;
-		border-radius: 5px;
 		background-color: #FFF;
 	}
 


### PR DESCRIPTION
These borders are a little stark with the dark theme.

This patch removed them completely so the avatar appears "floating", but
we could tone them down or make them the orange.

Only the first line needs to be removed, but without it the others do
nothing anymore.

```
      border: 1px solid #888;
      -webkit-border-radius: 6px;
      -moz-border-radius: 6px;
      border-radius: 6px;
```