### PR TITLE
Remove forced white background on gamers list

### DIFF
--- a/styles/gamersList.less
+++ b/styles/gamersList.less
@@ -28,7 +28,6 @@
 		-webkit-border-radius: 5px;
 		-moz-border-radius: 5px;
 		border-radius: 5px;
-		background-color: #FFF;
 		text-align: center;
 
 		&:hover {


### PR DESCRIPTION
On the dark theme, the list of gamers ends up with a white background.

Removing the CSS background-color element results in them taking on the
background color from the theme.

This has no effect on the light/default theme since it is setting the
background to the default background anyway.

The hover highlight color is a bit jaring on the dark theme, but that
will take more experimentation to find a good color and should go in
themeDark.less not here.