### PR TITLE
Remove forced white background on profile pages

### DIFF
--- a/styles/user.less
+++ b/styles/user.less
@@ -16,7 +16,6 @@
 		-webkit-border-radius: 5px;
 		-moz-border-radius: 5px;
 		border-radius: 5px;
-		background-color: #FFF;
 	}
 
 	#actions {


### PR DESCRIPTION
On the dark theme, user's avatar ends up with a white background. If the
image has transparency this will be misleading as that is not how it
will display elsewhere.

Removing the CSS background-color element results in them taking on the
background color from the theme.

This has no effect on the light/default theme since it is setting the
background to the default background anyway.