### PR TITLE
full text column for posts

### DIFF
--- a/docker/mysql/1-gp_tables.sql
+++ b/docker/mysql/1-gp_tables.sql
@@ -805,9 +805,11 @@ CREATE TABLE `posts` (
   `lastEdit` datetime NOT NULL,
   `timesEdited` tinyint(4) NOT NULL,
   `postAs` int(11) DEFAULT NULL,
+  `messageFullText` mediumtext COLLATE utf8_unicode_ci NULL,
   PRIMARY KEY (`postID`),
   KEY `threadID` (`threadID`),
-  KEY `authorID` (`authorID`)
+  KEY `authorID` (`authorID`),
+  FULLTEXT(`messageFullText`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 


### PR DESCRIPTION
Added column for docker.

To migrate an existing db without the column:
ALTER TABLE posts ADD COLUMN `messageFullText` mediumtext COLLATE utf8_unicode_ci NULL;
ALTER TABLE posts ADD FULLTEXT(`messageFullText`);