### PR TITLE
Tweak/improved page meta descriptions

### DIFF
--- a/forums/thread.php
+++ b/forums/thread.php
@@ -40,7 +40,7 @@
 	$threadManager->getPosts();
 
 	$dispatchInfo['title'] = $threadManager->getThreadProperty('title') . ' | ' . $dispatchInfo['title'];
-	$dispatchInfo['description'] = $threadManager->getKeyPost()->message;
+	$dispatchInfo['description'] = $threadManager->getKeyPostSnippet();
 ?>
 <?php	require_once(FILEROOT.'/header.php'); ?>
 		<h1 class="headerbar"> <?$threadManager->addThreadIcon()?><?=$threadManager->getThreadProperty('title')?></h1>

--- a/games/details.php
+++ b/games/details.php
@@ -12,7 +12,7 @@
 	if (!$gameInfo) { header('Location: /games/list/'); exit; }
 
 	$dispatchInfo['title'] = $gameInfo['title'];
-	$dispatchInfo['description'] = ($gameInfo['description'] ? ForumSearch::getTextSnippet(Post::extractFullText($gameInfo['description']),150) : 'No description provided.');
+	$dispatchInfo['description'] = ($gameInfo['description'] ? ForumSearch::getMetaAttribute($gameInfo['description']) : 'No description provided.');
 ?>
 <?php	require_once(FILEROOT . '/header.php'); ?>
 		<h1 class="headerbar"><i class="ra ra-d6"></i> <?=$gameInfo['title'] ?> <a ng-if="isGM" href="/games/{{gameID}}/edit/">[ EDIT ]</a></h1>

--- a/games/details.php
+++ b/games/details.php
@@ -1,5 +1,7 @@
 <?php $responsivePage=true;
 	require_once(FILEROOT.'/javascript/markItUp/markitup.bbcode-parser.php');
+	require_once(FILEROOT.'/includes/forums/Post.class.php');
+	require_once(FILEROOT.'/includes/forums/ForumSearch.class.php');
 
 	$gameID = intval($pathOptions[0]);
 
@@ -10,7 +12,7 @@
 	if (!$gameInfo) { header('Location: /games/list/'); exit; }
 
 	$dispatchInfo['title'] = $gameInfo['title'];
-	$dispatchInfo['description'] = "A {$systems->getFullName($gameInfo['system'])} game for {$gameInfo['numPlayers']} players. " . ($gameInfo['description'] ? $gameInfo['description'] : 'No description provided.');
+	$dispatchInfo['description'] = ($gameInfo['description'] ? ForumSearch::getTextSnippet(Post::extractFullText($gameInfo['description']),150) : 'No description provided.');
 ?>
 <?php	require_once(FILEROOT . '/header.php'); ?>
 		<h1 class="headerbar"><i class="ra ra-d6"></i> <?=$gameInfo['title'] ?> <a ng-if="isGM" href="/games/{{gameID}}/edit/">[ EDIT ]</a></h1>

--- a/includes/forums/ForumSearch.class.php
+++ b/includes/forums/ForumSearch.class.php
@@ -71,6 +71,10 @@
 			}
 		}
 
+		public static function getMetaAttribute($text){
+			return ForumSearch::getTextSnippet(str_replace('"',"&quot;",Post::extractFullText($text)),150);
+		}
+
 		public static function getTextSnippet($text, $maxChars) {
 			$words = preg_split('/[\s]+/', $text, null, PREG_SPLIT_DELIM_CAPTURE);
 			$wordCount = count($words);

--- a/includes/forums/ThreadManager.class.php
+++ b/includes/forums/ThreadManager.class.php
@@ -135,7 +135,7 @@
 			return $this->thread->getPosts($this->page);
 		}
 
-		public function getKeyPost() {
+		public function getKeyPostSnippet() {
 			global $mysql;
 
 			$posts = $this->thread->getPosts($this->page);
@@ -145,16 +145,18 @@
 			elseif (isset($_GET['p']) && intval($_GET['p']))
 				$checkFor = intval($_GET['p']);
 			elseif ($this->page != 1)
-				return $mysql->query("SELECT message FROM posts WHERE postID = {$this->thread->firstPostID}")->fetch();
+				return ForumSearch::getTextSnippet(Post::extractFullText($mysql->query("SELECT message FROM posts WHERE postID = {$this->thread->firstPostID}")->fetchColumn()),150);
 			else
-				return $posts[$this->thread->firstPostID];
+				return ForumSearch::getTextSnippet(Post::extractFullText($posts[$this->thread->firstPostID]->message),150);
 
 			foreach ($posts as $post) {
 				if ($checkFor == 'newPost' && ($post->getPostID() > $this->getThreadLastRead() || $this->thread->getLastPost('postID') == $post->getPostID()))
-					return $post;
-				elseif ($post->getPostID == $checkFor)
-					return $post;
+					return ForumSearch::getTextSnippet(Post::extractFullText($post->message),150);
+				elseif ($post->getPostID() == $checkFor)
+					return ForumSearch::getTextSnippet(Post::extractFullText($post->message),150);
 			}
+
+			return "";
 		}
 
 		public function updatePostCount() {

--- a/includes/forums/ThreadManager.class.php
+++ b/includes/forums/ThreadManager.class.php
@@ -145,15 +145,15 @@
 			elseif (isset($_GET['p']) && intval($_GET['p']))
 				$checkFor = intval($_GET['p']);
 			elseif ($this->page != 1)
-				return ForumSearch::getTextSnippet(Post::extractFullText($mysql->query("SELECT message FROM posts WHERE postID = {$this->thread->firstPostID}")->fetchColumn()),150);
+				return ForumSearch::getMetaAttribute($mysql->query("SELECT message FROM posts WHERE postID = {$this->thread->firstPostID}")->fetchColumn());
 			else
-				return ForumSearch::getTextSnippet(Post::extractFullText($posts[$this->thread->firstPostID]->message),150);
+				return ForumSearch::getMetaAttribute($posts[$this->thread->firstPostID]->message);
 
 			foreach ($posts as $post) {
 				if ($checkFor == 'newPost' && ($post->getPostID() > $this->getThreadLastRead() || $this->thread->getLastPost('postID') == $post->getPostID()))
-					return ForumSearch::getTextSnippet(Post::extractFullText($post->message),150);
+					return ForumSearch::getMetaAttribute($post->message);
 				elseif ($post->getPostID() == $checkFor)
-					return ForumSearch::getTextSnippet(Post::extractFullText($post->message),150);
+					return ForumSearch::getMetaAttribute($post->message);
 			}
 
 			return "";


### PR DESCRIPTION
Meta descriptions are shown in discord as page summaries.
This removes the BBCode, escapes quotes, and provides more meaningful page descriptions.