### PR TITLE
Include api hostname in opendkim InternalHosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ ucp/avatars/
 vendor/
 docker/apache/ssl/
 logs/
+docker/opendkim/keys/

--- a/docker/opendkim/opendkim.conf
+++ b/docker/opendkim/opendkim.conf
@@ -17,6 +17,6 @@ Socket                  inet:8891
 ReportAddress           postmaster@gamersplane.com
 SendReports             yes
 
-InternalHosts           127.0.0.1, gpv1-postfix
+InternalHosts           127.0.0.1, gpv1-postfix, gpv1-api.gamersplanev1_default
 
 PidFile         /var/run/opendkim/opendkim.pid


### PR DESCRIPTION
Needed so the API server can send mails.