### PR TITLE
Mitigate CVE-2024-2961 by patching out CN-EXT

### DIFF
--- a/docker/Dockerfile-php
+++ b/docker/Dockerfile-php
@@ -14,6 +14,9 @@ RUN apt-get install -y \
 	libpng-dev \
 	&& pecl install memcached \
 	&& docker-php-ext-enable memcached
+RUN sed -i -r 's/^(.*CN-?EXT)/##\1/' /usr/lib/x86_64-linux-gnu/gconv/gconv-modules \
+  && iconvconfig /usr/lib/x86_64-linux-gnu/gconv/ \
+  && iconv -l | grep -E 'CN-?EXT' && exit 1 || true
 RUN pecl install xdebug-2.7.0RC2 \
 	&& docker-php-ext-enable xdebug
 RUN pecl install mongodb-1.16.2 \

--- a/docker/Dockerfile-php
+++ b/docker/Dockerfile-php
@@ -15,8 +15,8 @@ RUN apt-get install -y \
 	&& pecl install memcached \
 	&& docker-php-ext-enable memcached
 RUN sed -i -r 's/^(.*CN-?EXT)/##\1/' /usr/lib/x86_64-linux-gnu/gconv/gconv-modules \
-  && iconvconfig /usr/lib/x86_64-linux-gnu/gconv/ \
-  && iconv -l | grep -E 'CN-?EXT' && exit 1 || true
+	&& iconvconfig /usr/lib/x86_64-linux-gnu/gconv/ \
+	&& iconv -l | grep -E 'CN-?EXT' && exit 1 || true
 RUN pecl install xdebug-2.7.0RC2 \
 	&& docker-php-ext-enable xdebug
 RUN pecl install mongodb-1.16.2 \


### PR DESCRIPTION
Disable iconv ISO-2022-CN-EXT in php api dockerfile to mitigate CVE with PHP